### PR TITLE
Allow multiple rule bodies in checks and policies

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -158,8 +158,8 @@ The logic language is descibed by the following EBNF grammar:
 
 <fact> ::= <name> "(" <sp>? <fact_term> (<sp>? "," <sp>? <fact_term> )* <sp>? ")"
 <rule> ::= <predicate> <sp>? "<-" <sp>? <rule_body>
-<check> ::= "check" <sp> "if" <sp> <rule_body>
-<policy> ::= ("allow" | "deny") <sp> "if" <sp> <rule_body>
+<check> ::= "check" <sp> "if" <sp> <rule_body> (<sp>? " or " <sp>? <rule_body>)* <sp>?
+<policy> ::= ("allow" | "deny") <sp> "if" <sp> <rule_body> (<sp>? " or " <sp>? <rule_body>)* <sp>?
 
 <rule_body> ::= <rule_body_element> <sp>? ("," <sp>? <rule_body_element> <sp>?)*
 <rule_body_element> ::= <predicate> | <expression>


### PR DESCRIPTION
The implementations allow having multiple rule bodies (separated with `or`): only one of them needs to match for the check / policy to match.