### PR TITLE
Align the spec with the rust implementation (and derived impls)

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -719,7 +719,7 @@ The symbol table is created from a default table containing, in order:
 - resource
 - operation
 - right
-- time
+- current_time
 - revocation_id
 
 tokens can be created from a different default table, as long as the creator,


### PR DESCRIPTION
While the spec mandates `time` to be part of the default symbol table, the rust implementation (and all those derived from it: afaik every impl except haskell) have `current_time`.

Since the rust and java impls are already deployed, it might make sense to align the spec with current use instead of fixing the libraries. Updating the spec will also require updating all documentation that references `time`, as well as the CLI.

The alternative is to fix the v2 support in all impls (except haskell), considering that v2 support is not effectively rolled out yet and that no v2 tokens are currently in the wild.