### PR TITLE
spec: general v2 cleanup

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -5,7 +5,7 @@
 Biscuit is a bearer token that supports offline attenuation, can be verified
 by any system that knows the root public key, and provides a flexible
 caveat language based on logic programming. It is serialized as
-Protocol Buffers [Protobuf], and designed to be small enough for storage in
+Protocol Buffers [^Protobuf], and designed to be small enough for storage in
 HTTP cookies.
 
 ### Vocabulary
@@ -14,15 +14,15 @@ HTTP cookies.
 rules creating more facts if conditions are met, and queries to test such conditions
 - check: a restriction on the kind of operation that can be performed with
 the token that contains it, represented as a datalog query in biscuit. For the operation
-to be valid, all of the checks defined in the token and the verifier must succeed
+to be valid, all of the checks defined in the token and the authorizer must succeed
 - allow/deny policies: a list of datalog queries that are tested in a sequence
-until one of them matches. They can only be defined in the verifier
+until one of them matches. They can only be defined in the authorizer
 - block: a list of datalog facts, rules and checks. The first block is the authority
 block, used to define the basic rights of a token
 - (Verified) Biscuit: a completely parsed biscuit, whose signatures and final proof
   have been successfully verified
 - Unverified Biscuit: a completely parsed biscuit, whose signatures and final proof
-  have not been verified yet. Manipulating unchecked biscuits can be useful for generic
+  have not been verified yet. Manipulating unverified biscuits can be useful for generic
   tooling (eg inspecting a biscuit without knowing its public key)
 - Authorized Biscuit: a completely parsed biscuit, whose signatures and final proof
   have been successfully verified and that was authorized in a given context, by running
@@ -42,26 +42,24 @@ block with more checks, thus restricting the rights of the new token, but they
 cannot remove existing blocks without invalidating the signature.
 
 The token is protected by public key cryptography operations: the initial creator
-of a token holds a secret key, and any verifier for the token needs only know
+of a token holds a secret key, and any verifier for the token needs only to know
 the corresponding public key.
 Any attenuation operation will employ ephemeral key pairs that are meant to be
 destroyed as soon as they are used.
 
-There is also a sealed version of that token that uses symmetric cryptography
-to generate a token that cannot be further attenuated, but is faster to verify.
+There is also a sealed version of that token that prevents further attenuation.
 
 The logic language used to design rights, checks, and operation data is a
 variant of datalog that accepts expressions on some data types.
 
-
 ## Semantics
 
 A biscuit is structured as an append-only list of blocks, containing *checks*,
-and describing authorization properties.  As with Macaroons[MACAROONS],
+and describing authorization properties.  As with Macaroons[^MACAROONS],
 an operation must comply with all checks in order to be allowed by the biscuit.
 
 Checks are written as queries defined in a flavor of Datalog that supports
-expressions on some data types[DATALOG], without support for negation. This
+expressions on some data types[^DATALOG], without support for negation. This
 simplifies its implementation and makes the check more precise.
 
 ### Logic language
@@ -70,18 +68,22 @@ simplifies its implementation and makes the check more precise.
 
 A Biscuit Datalog program contains *facts* and *rules*, which are made of
 *predicates* over the following types:
+
 - *variable*
 - *integer*
 - *string*
 - *byte array*
 - *date*
 - *boolean*
-- *set* a deduplicated list of values of any type, except *vaiable* or *set*
+- *set* a deduplicated list of values of any type, except *variable* or *set*
 
 While a Biscuit token does not use a textual representation for storage, we
 use one for parsing and pretty printing of Datalog elements.
+
 A *predicate* has the form `Predicate(v0, v1, ..., vn)`.
+
 A *fact* is a *predicate* that does not contain any *variable*.
+
 A *rule* has the form:
 `Pr(r0, r1, ..., rk) <- P0(t1_1, t1_2, ..., t1_m1), ..., Pn(tn_1, tn_2, ..., tn_mn), E0(v0, ..., vi), ..., Ex(vx, ..., vy)`.
 The part of the left of the arrow is called the *head* and on the right, the
@@ -90,22 +92,28 @@ The part of the left of the arrow is called the *head* and on the right, the
 We also define an *expression* `Ex` over the variables `v0` to `vi`. *Expressions*
 define a test of variable values when applying the *rule*. If the *expression*
 returns `false`, the *rule* application fails.
+
 A *query* is a type of *rule* that has no head. It has the following form:
 `?- P0(t1_1, t1_2, ..., t1_m1), ..., Pn(tn_1, tn_2, ..., tn_mn), C0(v0), ..., Cx(vx)`.
 When applying a *rule*, if there is a combination of *facts* that matches the
 body's predicates, we generate a new *fact* corresponding to the head (with the
 variables bound to the corresponding values).
-A *check* is a *query* for which the token validation will fail if it cannot
-produce any fact. If any of the cheks fails, the entire verification fails.
-An *allow policy* or *deny policy* is a *query*. If the query produces something,
+
+A *check* is a list of *query* for which the token validation will fail if it cannot
+produce any fact. A single query needs to match for the fact to succeed.
+If any of the cheks fails, the entire verification fails.
+
+An *allow policy* or *deny policy* is a list of *query*. If any of the queries produces something,
 the policy matches, and we stop there, otherwise we test the next one. If an
 *allow policy* succeeds, the token verification succeeds, while if a *deny policy*
 succeeds, the token verification fails. Those policies are tested after all of
 the *checks* have passed.
+
 We will represent the various types as follows:
+
 - variable: `$variable` (the variable name is converted to an integer id through the symbol table)
 - integer: `12`
-- string: `"hello"`
+- string: `"hello"` (strings are converted to integer ids through the symbol table)
 - byte array: `hex:01A2`
 - date in RFC 3339 format: `1985-04-12T23:20:50.52Z`
 - boolean: `true` or `false`
@@ -116,6 +124,7 @@ As an example, assuming we have the following facts: `parent("a", "b")`,
 `grandparent($x, $z) <- parent($x, $y), parent($y, $z)`, we will try to replace
 the predicates in the body by matching facts. We will get the following
 combinations:
+
 - `grandparent("a", "c") <- parent("a", "b"), parent("b", "c")`
 - `grandparent("b", "d") <- parent("b", "c"), parent("c", "d")`
 
@@ -127,22 +136,22 @@ rules application does not generate any new facts, we can stop.
 #### Data types
 
 An *integer* is a signed 64 bits integer. It supports the following
-operatios: lower, larger, lower or equal, larger or equal, equal, set
-inclusion and set exclusion.
+operations: lower than, greater than, lower than or equal, greater than or equal, equal, set
+inclusion.
 
 A *string* is a suite of UTF-8 characters. It supports the following
-operations: prefix, suffix, equal, set inclusion, set exclusion, regular expression.
+operations: prefix, suffix, equal, set inclusion, regular expression, concatenation (with `+`), substring test (with `.contains()`).
 
 A *byte array* is a suite of bytes. It supports the following
-operations: equal, set inclusion, set exclusion.
+operations: equal, set inclusion.
 
 A *date* is a 64 bit unsigned integer representing a TAI64. It supports the
-following operations: before, after.
+following operations: `<`, `<=` (before), `>`, `>=` (after), equality, set inclusion.
 
-A *boolean* is `true` or `false`.
+A *boolean* is `true` or `false`. It supports the following operations: `==`, `||`, `&&`, set inclusion. 
 
 A *set* is a deduplicated list of terms of the same type. It cannot contain
-variables or other sets.
+variables or other sets. It supports equality, intersection, union, set inclusion.
 
 #### Grammar
 
@@ -167,13 +176,14 @@ The logic language is descibed by the following EBNF grammar:
 <predicate> ::= <name> "(" <sp>? <term> (<sp>? "," <sp>? <term> )* <sp>? ")"
 <term> ::= <fact_term> | <variable>
 <fact_term> ::= <boolean> | <string> | <number> | <bytes> | <date> | <set>
+<set_term> ::= <boolean> | <string> | <number> | <bytes> | <date>
 
 
-<number> ::= [0-9]+
-<bytes> ::= "hex:" ([a-z] | [0-9] )+
+<number> ::= "-"? [0-9]+
+<bytes> ::= "hex:" ([a-z] | [0-9])+
 <boolean> ::= "true" | "false"
-<date> ::= [0-9]* "-" [0-9] [0-9] "-" [0-9] [0-9] "T" [0-9] [0-9] ":" [0-9] [0-9] ":" [0-9] [0-9] ( "Z" | ( "+" [0-9] [0-9] ":" [0-9] [0-9] ))
-<set> ::= "[" <sp>? ( <fact_term> ( <sp>? "," <sp>? <fact_term>)* <sp>? )? "]"
+<date> ::= [0-9]* "-" [0-9] [0-9] "-" [0-9] [0-9] "T" [0-9] [0-9] ":" [0-9] [0-9] ":" [0-9] [0-9] ( "Z" | ( ("+" | "-") [0-9] [0-9] ":" [0-9] [0-9] ))
+<set> ::= "[" <sp>? ( <fact_term> ( <sp>? "," <sp>? <set_term>)* <sp>? )? "]"
 
 <expression> ::= <expression_element> (<sp>? <operator> <sp>? <expression_element>)*
 <expression_element> ::= <expression_unary> | (<expression_term> <expression_method>? ) 
@@ -188,6 +198,7 @@ The logic language is descibed by the following EBNF grammar:
 ```
 
 The `name`, `variable` and `string` rules are defined as:
+
 - `name`:
   - first character is any UTF-8 letter character
   - following characters are any UTF-8 letter character, numbers, `_` or `:`
@@ -210,6 +221,7 @@ apply on facts created in the current or previous blocks. Facts, rules, checks
 and policies of the verifier are executed in the context of the authority block.
 
 Example:
+
 - the token contains `right("file1", "read")` in the first block
 - the token holder adds a block with the fact `right("file2", "read")`
 - the verifier adds:
@@ -229,7 +241,7 @@ One block can contain one or more checks.
 
 Their text representation is `check if` followed by the body of the query.
 There can be multiple queries inside of a check, it will succeed if any of them
-succeeds
+succeeds.
 
 Their text representation is `check if` followed by the body of the query.
 There can be multiple queries inside of a check, it will succeed if any of them
@@ -321,6 +333,8 @@ a deny policy succeeds, the token verification fails. If none of these policies
 are present, the verification will fail.
 
 They are written as `allow if` or `deny if` followed by the body of the query.
+Same as for checks, the body of a policy can contain multiple queries, separated
+by "or". A single query needs to match for the policy to match.
 
 ### Expressions
 
@@ -349,8 +363,9 @@ rule.
 
 #### Execution
 
-Expressions are internally represented as a serie of opcodes for a stack based
+Expressions are internally represented as a series of opcodes for a stack based
 virtual machine. There are three kinds of opcodes:
+
 - *value*: a raw value of any type. If it is a variable, the variable must also
 appear in a predicate, so the variable gets a real value for execution. When
 encountering a *value* opcode, we push it onto the stack
@@ -362,6 +377,7 @@ it pops two values from the stack, applies the operation, then pushes the result
 After executing, the stack must contain only one value, of the boolean type.
 
 Here are the currently defined unary operations:
+
 - *negate*: boolean negation
 - *parens*: returns its argument without modification (this is used when printing
 the expression, to avoid precedence errors)
@@ -373,11 +389,12 @@ Here are the currently defined binary operations:
 - *less or equal*, defined on integers and dates, returns a boolean
 - *greater or equal*, defined on integers and dates, returns a boolean
 - *equal*, defined on integers, strings, byte arrays, dates, set, returns a boolean
-- *contains* takes a set and another value as argument, returns a boolean. Between two sets, indicates if the first set is a superset of the second one
+- *contains* takes a set and another value as argument, returns a boolean. Between two sets, indicates if the first set is a superset of the second one.
+  between two strings, indicates a substring test. 
 - *prefix*, defined on strings, returns a boolean
 - *suffix*, defined on strings, returns a boolean
 - *regex*, defined on strings, returns a boolean
-- *add*, defined on integers, returns an integer
+- *add*, defined on integers, returns an integer. Defined on strings, concatenates them.
 - *sub*, defined on integers, returns an integer
 - *mul*, defined on integers, returns an integer
 - *div*, defined on integers, returns an integer
@@ -418,22 +435,23 @@ for the final decision on request validation.
 #### Deserializing the token
 
 The token must first be deserialized according to the protobuf format definition,
-of either a `Biscuit` or `SealedBiscuit`.
+of `Biscuit`.
 The cryptographic signature must be checked immediately after deserializing. For the
 `Biscuit` with a public key signature, the verifier must check that the public key of the
 authority block is the root public key it is expecting.
 
-A `Biscuit` or `SealedBiscuit` contains in its `authority` and `blocks` fields
+A `Biscuit` contains in its `authority` and `blocks` fields
 some byte arrays that must be deserialized as a `Block`.
 
-#### Verification process
+#### Authorization process
 
-The verifier will first create a default symbol table, and will append to that table the values
+The authorizer will first create a default symbol table, and will append to that table the values
 from the `symbols` field of each block, starting from the `authority` block and all the
 following blocks, ordered by their index.
 
 The verifier will create a Datalog "world", and add to this world its own facts and rules:
 ambient data from the request, lists of users and roles, etc.
+
 - the facts from the authority block
 - the rules from the authority block
 - for each following block:
@@ -445,11 +463,12 @@ ambient data from the request, lists of users and roles, etc.
 The verifier will generate a list of facts indicating revocation identifiers for
 the token. The revocation identifier for a block is its signature (as it uniquely
 identifies the block) serialized to a byte array (as in the Protobuf schema).
-For each of these if, a fact `revocation_id(<index of the block>, <byte array>)` will be generated
+For each of these if, a fact `revocation_id(<index of the block>, <byte array>)` will be generated.
 
-##### Verifying
+##### Authorizing
 
-From there, the verifier can start loading data from each block. First, for the authority block:
+From there, the authorizer can start loading data from each block. First, for the authority block:
+
 - load facts and rules from the block
 - run the Datalog engine on the facts and rules that were loaded
 - for each authority check or verifier check, validate it. If it fails, add an error to the error list
@@ -459,12 +478,14 @@ From there, the verifier can start loading data from each block. First, for the 
     - if it is a deny policy, the verification fails, store the result and stop here
 
 Then, for each following block:
+
 - remove all the previous rules (so the previous rules do not apply to new facts)
 - load facts and rules from the block
 - run the Datalog engine on the facts and rules that were loaded
 - for each block check, validate it. If it fails, add an error to the error list
 
 Returning the result:
+
 - if the error list is not empty, return the error list
 - check policy result:
   - if an allow policy matched, the verification succeeds
@@ -486,7 +507,7 @@ TODO: same as the verifier, but we do not need to know the root key
 
 ## Format
 
-The current version of the format is in [schema.proto](https://github.com/CleverCloud/biscuit/blob/master/schema.proto)
+The current version of the format is in [schema.proto](https://github.com/biscuit-auth/biscuit/blob/master/schema.proto)
 
 The token contains two levels of serialization. The main structure that will be
 transmitted over the wire is either the normal Biscuit wrapper:
@@ -515,6 +536,7 @@ message Proof {
 
 The `rootKeyId` is a hint to decide which root public key should be used
 for signature verification.
+
 Each block contains a serialized byte array of the Datalog data (`block`),
 the next public key (`nextKey`) and the signature of that block and key
 by the previous key.
@@ -528,44 +550,27 @@ in Protobuf format as well:
 
 ```proto
 message Block {
-  required uint32 index = 1;
-  repeated string symbols = 2;
-  repeated FactV0 facts_v0 = 3;
-  repeated RuleV0 rules_v0 = 4;
-  repeated CaveatV0 caveats_v0 = 5;
-  optional string context = 6;
-  optional uint32 version = 7;
-  repeated FactV1 facts_v1 = 8;
-  repeated RuleV1 rules_v1 = 9;
-  repeated CheckV1 checks_v1 = 10;
+  repeated string symbols = 1;
+  optional string context = 2;
+  optional uint32 version = 3;
+  repeated FactV2 facts_v2 = 4;
+  repeated RuleV2 rules_v2 = 5;
+  repeated CheckV2 checks_v2 = 6;
 }
 ```
 
 Each block contains a `version` field, indicating at which format version it
 was generated. Since a Biscuit implementation at version N can receive a valid
-token generated at version N-1, new implemetations must be able to recognize
+token generated at version N-1, new implementations must be able to recognize
 older formats. Moreover, when appending a new block, they cannot convert the
 old blocks to the new format (since that would invalidate the signature). So
 each block must carry its own version.
 An implementation must refuse token with a newer format than the one they know.
 An implementation must always generate tokens at the highest version it can do.
 
-### Version 0
+# Version 2
 
-This version corresponds to the initial development of Biscuit, kept for
-compatibility with current deployments, and to test version updates.
-
-It corresponds to the block fields with the `v0` suffix.
-The `caveats_v0` field must be converted to version 1 checks.
-Constraints are converted to expressions with binary operations.
-
-As an example, a integer constraint with id `15`, of kind "lower", with `10` in
-its `lower` field, will be converted to the serie of opcodes `$var, 10, <` with
-`var` corresponding to `15` in the symbol table.
-
-# Version 1
-
-This is the format for the 1.0 version of Biscuit.
+This is the format for the 2.0 version of Biscuit.
 
 It transport expressions as an array of opcodes.
 
@@ -573,8 +578,7 @@ It transport expressions as an array of opcodes.
 
 When transmitted as text, a Biscuit token should be serialized to a
 URLS safe base 64 string. When the context does not indicate that it
-is a Biscuit token, that base 64 string should be prefixed with `biscuit:`
-or `sealed-biscuit:` accordingly.
+is a Biscuit token, that base 64 string should be prefixed with `biscuit:`.
 
 ### Cryptography
 
@@ -607,7 +611,8 @@ Token {
   proof: Proof {
     nextSecret: sk_1,
   },
-}```
+}
+```
 
 #### Signature (appending)
 
@@ -637,31 +642,33 @@ Token {
   proof: Proof {
     nextSecret: sk_n+2,
   },
-}```
+}
+```
 
 #### Verifying
 
 For each block i from 0 to n:
 
-- verify(pk_i, sig_i, data_i + alg_i + pk_i+1)
+- verify(pk_i, sig_i, data_i + alg_i+1 + pk_i+1)
 
 If all signatures are verified, extract pk_n+1 from the last block and
 sk_n+1 from the proof field, and check that they are from the same
 key pair.
 
-#### Signature (appending)
+#### Signature (sealing)
 
 With a token containing blocks 0 to n:
 
 Block n contains:
+
 - `data_n`
 - `pk_n+1`
 - `sig_n`
 
 The token also contains `sk_n+1`
 
-We generate the signature `sig_n+1 = sign(sk_n+1, data_n + pk_n+1 + sig_n)` (we sign
-the last block with the last private key).
+We generate the signature `sig_n+1 = sign(sk_n+1, data_n + alg_n+1 + pk_n+1 + sig_n)` (we sign
+the last block and its signature with the last private key).
 
 The token will contain:
 
@@ -680,10 +687,10 @@ Token {
 
 For each block i from 0 to n:
 
-- verify(pk_i, sig_i, data_i+pk_i+1)
+- verify(pk_i, sig_i, data_i+alg_i+1+pk_i+1)
 
 If all signatures are verified, extract pk_n+1 from the last block and
-sig from the proof field, and check `verify(pk_n+1, sig_n+1, data_n+pk_n+1+sig_n)`
+sig from the proof field, and check `verify(pk_n+1, sig_n+1, data_n+alg_n+1+pk_n+1+sig_n)`
 
 ### Blocks
 
@@ -691,12 +698,12 @@ A block is defined as follows in the schema file:
 
 ```proto
 message Block {
-  required uint32 index = 1;
-  repeated string symbols = 2;
-  repeated Fact   facts = 3;
-  repeated Rule   rules = 4;
-  repeated Rule   caveats = 5;
-  optional string context = 6;
+  repeated string symbols = 1;
+  optional string context = 2;
+  optional uint32 version = 3;
+  repeated FactV2 facts_v2 = 4;
+  repeated RuleV2 rules_v2 = 5;
+  repeated CheckV2 checks_v2 = 6;
 }
 ```
 
@@ -714,6 +721,7 @@ running the logic engine does not need to know the content of that list,
 pretty printing facts, rules and results will use it.
 
 The symbol table is created from a default table containing, in order:
+
 - read
 - write
 - resource
@@ -764,12 +772,12 @@ their list.
 ## Test cases
 
 We provide sample tokens and the expected result of their verification at
-[https://github.com/CleverCloud/biscuit/tree/master/samples](https://github.com/CleverCloud/biscuit/tree/master/samples)
+[https://github.com/biscuit-auth/biscuit/tree/master/samples](https://github.com/CleverCloud/biscuit/tree/master/samples)
 
 ## References
 
- - ProtoBuf: https://developers.google.com/protocol-buffers/
- - DATALOG: "Datalog with Constraints: A Foundation for Trust Management Languages" http://crypto.stanford.edu/~ninghui/papers/cdatalog_padl03.pdf
- - Trust Management Languages" https://www.cs.purdue.edu/homes/ninghui/papers/cdatalog_padl03.pdf
- - MACAROONS: "Macaroons: Cookies with Contextual Caveats for Decentralized Authorization in the Cloud" https://ai.google/research/pubs/pub41892
+- "Trust Management Languages" https://www.cs.purdue.edu/homes/ninghui/papers/cdatalog_padl03.pdf
 
+[^ProtoBuf]: ProtoBuf https://developers.google.com/protocol-buffers/
+[^DATALOG]: "Datalog with Constraints: A Foundation for Trust Management Languages" http://crypto.stanford.edu/~ninghui/papers/cdatalog_padl03.pdf
+[^MACAROONS]: "Macaroons: Cookies with Contextual Caveats for Decentralized Authorization in the Cloud" https://ai.google/research/pubs/pub41892


### PR DESCRIPTION
- markdown fixes
- wording fixes
- grammar fixes
- removed v0 and v1 spec
- removed _set exclusion_ from the supported operations
- added `+` and `.contains()` support on strings