### PR TITLE
ed25519 keys don't need the `hex:` prefix

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -179,12 +179,12 @@ The logic language is described by the following EBNF grammar:
 
 <predicate> ::= <name> "(" <sp>? <term> (<sp>? "," <sp>? <term> )* <sp>? ")"
 <term> ::= <fact_term> | <variable>
-<fact_term> ::= <boolean> | <string> | <number> | <bytes> | <date> | <set>
+<fact_term> ::= <boolean> | <string> | <number> | ("hex:" <bytes>) | <date> | <set>
 <set_term> ::= <boolean> | <string> | <number> | <bytes> | <date>
 
 
 <number> ::= "-"? [0-9]+
-<bytes> ::= "hex:" ([a-z] | [0-9])+
+<bytes> ::= ([a-z] | [0-9])+
 <boolean> ::= "true" | "false"
 <date> ::= [0-9]* "-" [0-9] [0-9] "-" [0-9] [0-9] "T" [0-9] [0-9] ":" [0-9] [0-9] ":" [0-9] [0-9] ( "Z" | ( ("+" | "-") [0-9] [0-9] ":" [0-9] [0-9] ))
 <set> ::= "[" <sp>? ( <set_term> ( <sp>? "," <sp>? <set_term>)* <sp>? )? "]"


### PR DESCRIPTION
The rust implementation doesn't support it, and the haskell impl will get rid of it as well for compatibility.